### PR TITLE
Update 59901.tokenlist.json to add Test eMetis and Test seMetis  to Netswap.io token list

### DIFF
--- a/59901.tokenlist.json
+++ b/59901.tokenlist.json
@@ -41,6 +41,22 @@
         },
         {
             "chainId": 59901,
+            "address": "0xDF5b62fa100b5f67C5a9A5DA500FE7139d169cFe",
+            "decimals": 18,
+            "name": "Test eMETIS",
+            "symbol": “eMETIS",
+            "logoURI": "https://raw.githubusercontent.com/nass2010/testnet.enkixyz.com/main/static/media/ekMetis.f0bd93e976e880cffa80bbbe6c8797e8.svg"
+        },
+        {
+            "chainId": 59901,
+            "address": "0xd11bB6839aF15d0d62F015d97467724c1f8f9489",
+            "decimals": 18,
+            "name": "Test seMETIS",
+            "symbol": “seMETIS",
+            "logoURI": "https://raw.githubusercontent.com/nass2010/testnet.enkixyz.com/main/static/media/sekMetis.d6447f270473bebd8ca4d9a19dfc95dc.svg"
+        },
+        {
+            "chainId": 59901,
             "address": "0xdE89C3A592FBcd9c34A0329919F2904d4114Bc83",
             "decimals": 18,
             "name": "Netswap Token",


### PR DESCRIPTION
Add Test eMetis and Test seMetis to the listed tokens on Netswap.io on the Metis Sepolia testnet.

On the ENKI.xyz app hovering over the Metis to eMetis exchange button displays the following message: "It’s not yet possible to exchange Metis into Metis currently. Please go to the exchange to exchange it by yourself."

Clicking on the exchange button brings up a dialog box with the following message: "Redemption Coming Soon! We're working on it! The redemption feature for SEtoken isn't available just yet. In the meantime, feel free to redeem Mtoken on the secondary market. Swap eMetis/Metis on Netswap"

Currently neither Test eMetis nor Test seMetis are listed on Netswap.io. This proposes to add them to the Netswap.io listings. Links to the .svg logo files in the nass2010/testnet.enkixyz.com/ repository have been provided for each.